### PR TITLE
Adds embedded exercises

### DIFF
--- a/_includes/assets/custom.scss
+++ b/_includes/assets/custom.scss
@@ -108,12 +108,6 @@ a.caption {
   color: white;
 }
 
-
-/* Track */
-.bogl-repl-result::-webkit-scrollbar-track {
-  background: $primary-color;
-}
-
 .bogl-embed-editor .right div {
   height: 80%;
   border-radius: 4px;
@@ -134,6 +128,14 @@ a.caption {
 
 .bogl-embed-editor .right input:focus {
   outline-width: 0;
+}
+
+.bogl-exercise .right div {
+  height: 80%;
+}
+
+.bogl-exercise .bogl::before {
+  content: "•λ BoGL Exercise";
 }
 
 @media(max-width: 800px) {
@@ -165,4 +167,61 @@ a.caption {
     outline-width: 0;
   }
 
+}
+
+/* Exercise stuff */
+.exercise-response {
+  padding: 8px;
+  border-radius: 4px;
+  display: inline;
+  margin: 4px 0;
+  height: 20px;
+}
+
+.correct {
+  background: #fff;
+  color: #0a0;
+}
+
+.incorrect {
+  background: #fff;
+  color: #a00;
+}
+
+.bogl-exercise-check {
+  transition: 0.3s;
+}
+
+.bogl-exercise-check:hover {
+  cursor: pointer;
+  box-shadow: 0 0 5px #000 inset;
+}
+
+/* Checking items */
+.bogl-check-pass {
+  background-color: #0f0;
+}
+
+.bogl-check-pass div .bogl-exercise-check {
+  border-color: #0f0;
+  color: #090;
+}
+
+.bogl-check-failure {
+  background-color: #f00;
+}
+
+.bogl-check-failure div .bogl-exercise-check {
+  border-color: #f00;
+  color: #900;
+}
+
+.exercise {
+  font-family: "Source Sans Pro", Helvetica, Arial, sans-serif;
+  background: #fff;
+  opacity: 0.8;
+  padding: 8px;
+  border-radius: 4px;
+  margin-bottom: 4px;
+  margin-top: 4px;
 }

--- a/_includes/exercise_module_template.html
+++ b/_includes/exercise_module_template.html
@@ -1,0 +1,14 @@
+<script src="{{site.baseurl}}/assets/js/embed_test.js" defer></script>
+<!--BoGL Exercise-->
+<div class="bogl-embed-editor bogl-exercise">
+  <div class="bogl"></div>
+  <div class="left bogl-exercise-code" contenteditable="true">
+    {% if page.content %}
+	  	{{ include.content | newline_to_br }}
+	  {% endif %}
+  </div>
+  <div class="right">
+    <div class="bogl-exercise-result"></div>
+    <input class="bogl-exercise-check" type="button" value="Check" checks="{{ include.checks | newline_to_br }}" expects="{{ include.expects | newline_to_br }}"/>
+  </div>
+</div>

--- a/assets/js/embed_test.js
+++ b/assets/js/embed_test.js
@@ -1,3 +1,4 @@
+"use strict";
 //
 // Embedded BoGL Editor JS
 //
@@ -67,7 +68,6 @@
   function exitInputHandling() {
     setCommandInput([]);
     setInputState(false);
-    command = "";
   }
 
   // Used to parse response from back-end server
@@ -210,158 +210,312 @@
     resultElm.parentElement.scrollTop = resultElm.parentElement.scrollHeight;
   }
 
+  function updatePlainResult(resultElm,content) {
+    resultElm.innerHTML += content + "<br/><br/>";
+    // force scroll to new results, if any
+    resultElm.scrollTop = resultElm.scrollHeight;
+    resultElm.parentElement.scrollTop = resultElm.parentElement.scrollHeight;
+  }
+
+  // retrieves the raw code from an element
+  function getRawCode(elm) {
+    let code = elm.innerHTML;
+    // replace <br> with linebreaks
+    code = code.replaceAll(/<div><br><\/div>/gi, '\n');
+    // replace <div> and </div> with nothing!
+    code = code.replaceAll(/(?:<div>)|(?:<\/div>)/gi, '\n');
+    // cleanup leftover <br> tags
+    code = code.replaceAll(/<br>/gi, '\n');
+    // replae &gt; and &lt; w/ > & < respectively
+    code = code.replaceAll(/&gt;/gi, '>');
+    code = code.replaceAll(/&lt;/gi, '<');
+    return code;
+  }
+
+  // Runs bogl code on the server, returns the result as JSON
+  function runBOGL(name,code,cmd,commandInput,elm,callback) {
+    let respStatus = 0;
+
+    fetch(
+        "https://bogl.engr.oregonstate.edu/api_1/runCode"
+        ,{
+            method: "POST",
+            headers: {
+              'Accept': 'application/json',
+              'Content-Type': 'application/json',
+              'Allow': '*'
+            },
+            body: JSON.stringify({
+                file    : code,
+                prelude : "", // no prelude for these examples...
+                input   : cmd,
+                buffer  : commandInput,
+                programName: name
+            })
+    }).then(function(res) {
+      respStatus = res.status;
+      return res.json();
+
+    }).then(function(resp) {
+      if(name !== "Exercise") {
+        // if not an exercise, it's okay to show the command
+        updateResults(elm, cmd + "<br/><br/>" + parse_response(resp));
+
+      } else {
+        // otherwise, hide command in the response
+        updateResults(elm, parse_response(resp));
+
+      }
+
+
+      callback({
+        response: resp,
+        status: respStatus
+      });
+
+    }).catch((error) => {
+      if((error instanceof SyntaxError || (error.name && error.name === "SyntaxError")) && respStatus === 504) {
+        // gateway timeout
+        updateResults(elm, " 🤖 BoGL Says: Unable to finish running your program, or not currently online. Double check your code, or check back later! ");
+
+      } else if((error instanceof SyntaxError || (error.name && error.name === "SyntaxError"))) {
+        // bad parse error
+        updateResults(elm, " 🤖 BoGL Says: Your program was unable to be understood. Please double check it and try again! ");
+
+      } else if((error instanceof TypeError || (error.name && error.name === "TypeError")) && respStatus === 0) {
+        // likely JS disabled
+        updateResults(elm, " 🤖 BoGL Says: Unable to execute your program. Make sure that Javascript is enabled and try again! ");
+
+      } else if((error instanceof TypeError || (error.name && error.name === "TypeError"))) {
+        // something else?
+        console.error(error);
+        updateResults(elm, " 🤖 BoGL Says: Unable to execute your program, please double check your code and try again. ");
+
+      } else {
+        // general error
+        updateResults(elm, " 🤖 BoGL Says: An error occurred: " + error + " ");
+
+      }
+    });
+  }
+
+  // apply a function over an array
+  const fapply = f => ls => {
+    for(let x = 0; x < ls.length; x++) {
+      f(ls[x])
+    }
+  }
+
+  const map = f => ls => {
+    for(let x = 0; x < ls.length; x++) {
+      ls[x] = f(ls[x])
+    }
+    return ls;
+  }
+
+  // wrappers for get
+  const getByClass = n => document.getElementsByClassName(n);
+  const getById = n => document.getElementById(n);
+
+  // onkeydown
+  const onKeyDown = f => e => e.addEventListener("keydown", f);
+  const onClick = f => e => e.addEventListener("click", f);
+
+  // repeats 'f' 'x' times into an array...repeat (5) (3) == [5,5,5]
+  const repeat = f => x => [...Array(x)].map(x => f);
+
+  /*
+   * Runs the repl with an input element, a result element, bogl code element, and an event
+   * Also takes in a 'lastCmd', which is effectively state from the last input. While input
+   * is being processed, this will repeatedly take the value of the expression that started input,
+   * until 'input' mode is cleared or finished.
+   */
+  const runREPL = lastCmd => inputx => resultx => codeElm => e => {
+
+    if(e.keyCode != 13) {
+      return;
+    }
+
+    // prevent bubble
+    e.preventDefault();
+
+    let code = getRawCode(codeElm);
+
+    // store command
+    let cmd = inputx.value;
+    // clear input val
+    inputx.value = "";
+
+    if(cmd.replaceAll(/\s/gi, '') === "") {
+      // nothing to run
+      return;
+    }
+
+    // trim whitespace
+    cmd = cmd.replace(/^\s+/, '').replace(/\s+$/, '');
+
+    // speak haskell and colors change (this can be removed if it's annoying...)
+    if(cmd.match(/haskell/i)) {
+      codeElm.parentElement.className+= " haskell";
+      updateResults(resultx, "The language that BoGL was inspired and built from, <a href=\"https://www.haskell.org/\" target=\"_blank\">https://haskell.org/</a>");
+      return;
+
+    } else if(cmd.match(/bogl/i)) {
+      codeElm.parentElement.className= "bogl-embed-editor";
+      updateResults(resultx, "BoGL");
+      return;
+
+    } else if(cmd.match(/help/i)) {
+      updateResults(resultx, "Help<br/><br/>\
+      This is a tiny version of the BoGL editor.<br/><br/>\
+      - <a href=\"https://bogl.engr.oregonstate.edu/\" target=\"_blank\">Full BoGL Editor</a><br/>\
+      - <a href=\"https://bogl.engr.oregonstate.edu/tutorials/\" target=\"_blank\">Tutorials</a>");
+      return;
+
+    }
+
+    if (inputState) {
+        // put it into 'input' instead
+        input(cmd);
+        cmd = lastCmd;
+
+    } else {
+      lastCmd = cmd;
+
+    }
+
+    // check to ':t ' to request an expression result type
+    let regex = /^:t\s+/;
+    if(cmd.match(regex)) {
+      // pull off the prefaced type instruction, but note that we would like to report a type once done
+      cmd = cmd.replace(regex,'');
+      setReportType(true);
+      reportType = true;
+
+    } else {
+      // do not report type
+      setReportType(false);
+      reportType = false;
+
+    }
+
+    if(cmd == "clear") {
+      updateResults(resultx, cmd + "<br/><br/>" + clear());
+      return;
+
+    }
+
+    runBOGL("Program",code,cmd,commandInput,resultx, (data) => {
+      // ran successfully
+    });
+  }
+
+
+  const compareResults = a => b => {
+    a = a.replaceAll(/\s+/gi,' ')
+    //a = a.replaceAll(/<br\/>/, '\n')
+
+    b = b.replaceAll(/\s+/gi, ' ')
+    //b = b.replaceAll(/<br\/>/, '\n')
+
+    return a == b
+  }
+
+
+  // verifies each exercise test until done, then reports the results
+  const verifyEachExerciseTest = checkElm => codeElm => code => checks => expects => resultElm => {
+    let check = checks.pop()
+    let expect = expects.pop()
+
+    runBOGL("Exercise", code, check, commandInput, resultElm, (data) => {
+      // extract the value
+      let actual = parse_response(data.response);
+
+      // check if this is a failure
+      if (!compareResults(actual)(expect)) {
+        // report failure
+        codeElm.parentElement.className = "bogl-embed-editor bogl-exercise bogl-check-failure";
+        checkElm.value = "Re-Check";
+        if(data.response[data.response.length-1].tag == 'SpielValue') {
+          updateResults(resultElm, "Expected:<br/>"+expect+"<br/>but got<br/>"+actual);
+        }
+        updatePlainResult(resultElm, " <span class='exercise-response incorrect'>❌️ Try Again.</span>");
+
+      } else if(checks.length > 0) {
+        // more to check
+        verifyEachExerciseTest (checkElm) (codeElm) (code) (checks) (expects) (resultElm)
+
+      } else {
+        // nothing more to check, report a pass
+        codeElm.parentElement.className = "bogl-embed-editor bogl-exercise bogl-check-pass";
+        checkElm.value = "Passed";
+        updatePlainResult(resultElm, " <span class='exercise-response correct'>✅️ Correct</span>");
+
+      }
+    })
+  }
+
+
+  // Verify an exercise
+  const verifyExercise = codeElm => checkElm => resultElm => e => {
+    // prevent bubble
+    e.preventDefault();
+
+    // extract checks & expects
+    let checks = checkElm.getAttribute("checks").split("<br />").map(x => x.trim());
+    let expects = checkElm.getAttribute("expects").split("<br />").map(x => x.trim());
+
+    let code = getRawCode(codeElm);
+
+    updateResults(resultElm, "checking...");
+
+    // verify all tests pass for this exercise
+    verifyEachExerciseTest (checkElm) (codeElm) (code) (checks) (expects) (resultElm)
+
+  }
+
+
   window.onload = (function() {
 
-    let lastCmd = "";
-    let boglCode= document.getElementsByClassName("bogl-code");
+    //
+    // regular mini-editor
+    //
+    // retrieve and cleanup bogl code items
+    const codeElms = getByClass("bogl-code");
+    fapply (y => y.innerHTML = y.innerHTML.replaceAll(/\n/gi, '<br/>')) (codeElms);
 
-    // clean up all code with proper html linebreaks
-    for(let x = 0; x < boglCode.length; x++) {
-      boglCode[x].innerHTML = boglCode[x].innerHTML.replaceAll(/\n/gi, '<br/>');
+    // get result elements
+    const results = getByClass("bogl-repl-result");
+    // get input elements
+    const inputs = getByClass("bogl-repl-run");
+
+    // create array of 'last' commands to retain
+    let lastCmd = repeat ("") (results.length)
+
+    // map the keydown event for each REPL
+    for(let x = 0; x < results.length; x++) {
+      onKeyDown(runREPL (lastCmd[x]) (inputs[x]) (results[x]) (codeElms[x])) (inputs[x]);
     }
 
-    let results = document.getElementsByClassName("bogl-repl-result");
-    let inputs  = document.getElementsByClassName("bogl-repl-run");
-    for(let x = 0; x < inputs.length; x++) {
-      inputs[x].addEventListener("keydown", (function(e) {
-        if(e.keyCode != 13) {
-          return;
-        }
 
-        // prevent buble
-        e.preventDefault();
+    //
+    // interactive exercises
+    //
+    const exerciseCodeElms = getByClass("bogl-exercise-code");
+    // clean bogl code
+    fapply (y => y.innerHTML = y.innerHTML.replaceAll(/\n/gi, '<br/>')) (exerciseCodeElms);
 
-        let code = boglCode[x].innerHTML;
-		    // replace &gt; with >
-        code = code.replaceAll(/&gt;/gi, '>'); // Added by Aiden Nelson
-        // replace <br> with linebreaks
-        code = code.replaceAll(/<div><br><\/div>/gi, '\n');
-        // replace <div> and </div> with nothing!
-        code = code.replaceAll(/(?:<div>)|(?:<\/div>)/gi, '\n');
-        // cleanup leftover <br> tags
-        code = code.replaceAll(/<br>/gi, '\n');
-        // also fix &lt tags
-        code = code.replaceAll(/&lt;/gi, '<');
+    // retrieve exercise items
+    const exerciseResults = getByClass("bogl-exercise-result");
+    const exerciseChecks = getByClass("bogl-exercise-check");
 
-        let respStatus = 0;
-
-        let cmd = inputs[x].value;
-        inputs[x].value = "";
-
-        if(cmd.replaceAll(/\s/gi, '') === "") {
-          // nothing to run
-          return;
-        }
-
-        // trim whitespace
-        cmd = cmd.replace(/^\s+/, '').replace(/\s+$/, '');
-
-        // speak haskell and colors change (this can be removed if it's annoying...)
-        if(cmd.match(/haskell/i)) {
-          boglCode[x].parentElement.className+= " haskell";
-          updateResults(results[x], "The language that BoGL was inspired and built from, <a href=\"https://www.haskell.org/\" target=\"_blank\">https://haskell.org/</a>");
-          return;
-
-        } else if(cmd.match(/bogl/i)) {
-          boglCode[x].parentElement.className= "bogl-embed-editor";
-          updateResults(results[x], "BoGL");
-          return;
-
-        } else if(cmd.match(/help/i)) {
-          updateResults(results[x], "Help<br/><br/>\
-          This is a tiny version of the BoGL editor.<br/><br/>\
-          - <a href=\"https://bogl.engr.oregonstate.edu/\" target=\"_blank\">BoGL Editor</a><br/>\
-          - <a href=\"https://bogl.engr.oregonstate.edu/tutorials/\" target=\"_blank\">Tutorials</a>");
-          return;
-
-        }
-
-        if (inputState) {
-            // put it into 'input' instead
-            input(cmd);
-            cmd = lastCmd;
-
-        } else {
-          lastCmd = cmd;
-
-        }
-
-        // check to ':t ' to request an expression result type
-        let regex = /^:t\s+/;
-        if(cmd.match(regex)) {
-          // pull off the prefaced type instruction, but note that we would like to report a type once done
-          cmd = cmd.replace(regex,'');
-          setReportType(true);
-          reportType = true;
-
-        } else {
-          // do not report type
-          setReportType(false);
-          reportType = false;
-
-        }
-
-        if(cmd == "clear") {
-          updateResults(results[x], cmd + "<br/><br/>" + clear());
-          return;
-
-        }
-
-        fetch(
-            //"http://localhost:3000/api_1/runCode"
-            "https://bogl.engr.oregonstate.edu/api_1/runCode"
-            ,{
-                method: "POST",
-                headers: {
-                  'Accept': 'application/json',
-                  'Content-Type': 'application/json',
-                  'Allow': '*'
-                },
-                body: JSON.stringify({
-                    file    : code,
-                    prelude : "",
-                    input   : cmd,
-                    buffer  : commandInput,
-					programName : 'programName'
-                })
-        }).then(function(res) {
-          respStatus = res.status;
-          return res.json();
-
-        }).then(function(resp) {
-          updateResults(results[x], cmd + "<br/><br/>" + parse_response(resp));
-
-        }).catch((error) => {
-          if((error instanceof SyntaxError || (error.name && error.name === "SyntaxError")) && respStatus === 504) {
-            // gateway timeout
-            //console.dir(error);
-            print(" 🤖 BoGL Says: Unable to finish running your program, or not currently online. Double check your code, or check back later! ");
-
-          } else if((error instanceof SyntaxError || (error.name && error.name === "SyntaxError"))) {
-            // bad parse error
-            //console.dir(error);
-            print(" 🤖 BoGL Says: Your program was unable to be understood. Please double check it and try again! ");
-
-          } else if((error instanceof TypeError || (error.name && error.name === "TypeError")) && respStatus === 0) {
-            // likely JS disabled
-            //console.dir(error);
-            print(" 🤖 BoGL Says: Unable to execute your program. Make sure that Javascript is enabled and try again! ");
-
-          } else if((error instanceof TypeError || (error.name && error.name === "TypeError"))) {
-            // something else?
-            //console.dir(error);
-            print(" 🤖 BoGL Says: Unable to execute your program, please double check your code and try again. ");
-
-          } else {
-            // general error
-            //console.dir(error);
-            print(" 🤖 BoGL Says: An error occurred: " + error + " ");
-
-          }
-        });
-
-      }));
+    // set on click listeners for exercises
+    for(let x = 0; x < exerciseResults.length; x++) {
+      onClick(verifyExercise (exerciseCodeElms[x]) (exerciseChecks[x]) (exerciseResults[x])) (exerciseChecks[x]);
     }
+
   });
+
+  console.info("> 🤖 BoGL Embedded Editor Version 0.2.0");
 
 })();


### PR DESCRIPTION
Adds in embedded exercises, which can be written in the following style:
```
{% include exercise_module_template.html
content = "game Test

snd : (Int,Int) -> Int
snd(x,y) = 0
"

checks="snd(2,2)
snd(90,3)
snd(1,9)"

expects="2
3
9"
%}
```
In the above example, the function `snd` should return 'y', but it can be intentionally left wrong. Whenever the exercise is tested, each 'checks' entry is run and verified that the results match with each 'expects' entry. If everything passes it work, otherwise it fails.

The following is a quick gif of it in action. Let me know if there's anything you think that could be changed/added. There is a quirk right now that the the 'checks' and 'expects' entries are separated by line breaks, but must start immediately after the opening ", otherwise it doesn't work quite right. Beyond that there can be 1 or more entries, allowing multiple tests for each exercise to verify it works as expected.

I also changed quite a lot of the JS. I know we made an adjustment before due to some issues I think...so it might be worth a look over. Certainly not perfect, but we can refine as we go, maybe try this out in a few spots.

![bogl-exercise-example](https://user-images.githubusercontent.com/5070304/98874615-6d417000-242f-11eb-838a-e00d4fb1f65e.gif)
